### PR TITLE
Imu optimized back end

### DIFF
--- a/MQTTServer/include/sensors/imu.hpp
+++ b/MQTTServer/include/sensors/imu.hpp
@@ -24,8 +24,6 @@ class IMUSensor : public SensorBase {
         float roll;
         float pitch;
         float yaw;
-        float battery_temp;
-        float power;
         float heading_deg;
         float speed;
     };

--- a/MQTTServer/src/sensors/imu.cpp
+++ b/MQTTServer/src/sensors/imu.cpp
@@ -16,8 +16,6 @@ void IMUSensor::generate_data(IMUData& data) {
         data.roll = random_value(180.0f, -180.0f);
         data.yaw = random_value(180.0f, -180.0f);
         data.pitch = random_value(180.0f, -180.0f);
-        data.battery_temp = random_value(60.0f, 20.0f);
-        data.power = random_value(100.0f, 50.0f);
         data.heading_deg = 0;
         data.speed = 0;
 
@@ -40,11 +38,6 @@ void IMUSensor::generate_data(IMUData& data) {
             data.yaw -= 360;
         } else if (data.yaw < -180) {
             data.yaw += 360;
-        }
-        data.battery_temp += random_value(2.0f, -2.0f);
-        data.power += random_value(0.0f, -0.001f);
-        if (data.power < 0) {
-            data.power = 0;
         }
         data.heading_deg += random_value(5.0f, -5.0f);
         if (data.heading_deg > 180) {

--- a/launch-program.sh
+++ b/launch-program.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Starting the SSRT Onboard Software..."
+
+# Must go to MQTTServer directory otherwise program won't run
+cd MQTTServer
+./build/ssrt-onboard-software


### PR DESCRIPTION
# Description
Just removed battery temp and power from all the back end, so the front end will not receive any battery temp and power data. Publishes fewer bytes of data per iteration now. 20 instead of 28 at a time

# Known Issues
Also includes the unfinished launch script that will be used to automatically start the back end when the rover turns on
